### PR TITLE
Add `imageExtensions` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,16 +2,16 @@
  * @typedef {import('mdast').Root} Root
  * @typedef {import('mdast').Image} Image
  * @typedef {import('mdast').Link} Link
+ *
+ * @typedef Options
+ *   Configuration (optional).
+ * @property {Array<string>} [imageExtensions]
+ *   File extensions (without dot) to treat as images.
  */
 
 import isUrl from 'is-url'
 import {visitParents} from 'unist-util-visit-parents'
 import {is} from 'unist-util-is'
-
-/**
- * @typedef Options
- * @property {Array<string>} [imageExtensions] file extensions of images
- */
 
 const isImgPath = (/** @type {string} */ value) =>
   value.startsWith('/') || value.startsWith('./') || value.startsWith('../')
@@ -32,13 +32,13 @@ export const defaultImageExtensions = [
 /**
  * Plugin to add a simpler image syntax.
  *
- * @type {import('unified').Plugin<[Options?], Root>}
+ * @type {import('unified').Plugin<[Options?]|void[], Root>}
  */
 export default function remarkImages({
   imageExtensions = defaultImageExtensions
 } = {}) {
-  const isImgExt = (/** @type {string} */ value) =>
-    new RegExp(`\\.(${imageExtensions.join('|')})$`).test(value)
+  const imgExtRegex = new RegExp(`\\.(${imageExtensions.join('|')})$`)
+  const isImgExt = (/** @type {string} */ value) => imgExtRegex.test(value)
 
   return (tree) => {
     visitParents(tree, 'text', (node, parents) => {

--- a/index.js
+++ b/index.js
@@ -8,17 +8,38 @@ import isUrl from 'is-url'
 import {visitParents} from 'unist-util-visit-parents'
 import {is} from 'unist-util-is'
 
-const isImgExt = (/** @type {string} */ value) =>
-  /\.(svg|png|jpg|jpeg|gif)$/.test(value)
+/**
+ * @typedef Options
+ * @property {Array<string>} [imageExtensions] file extensions of images
+ */
+
 const isImgPath = (/** @type {string} */ value) =>
   value.startsWith('/') || value.startsWith('./') || value.startsWith('../')
 
 /**
+ * Extensions recognized as images by default
+ */
+export const defaultImageExtensions = [
+  'svg',
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'webp',
+  'avif'
+]
+
+/**
  * Plugin to add a simpler image syntax.
  *
- * @type {import('unified').Plugin<void[], Root>}
+ * @type {import('unified').Plugin<[Options?], Root>}
  */
-export default function remarkImages() {
+export default function remarkImages({
+  imageExtensions = defaultImageExtensions
+} = {}) {
+  const isImgExt = (/** @type {string} */ value) =>
+    new RegExp(`\\.(${imageExtensions.join('|')})$`).test(value)
+
   return (tree) => {
     visitParents(tree, 'text', (node, parents) => {
       const value = String(node.value).trim()

--- a/readme.md
+++ b/readme.md
@@ -121,12 +121,17 @@ Transform URLs in text that reference images (`png`, `svg`, `jpg`, `jpeg`, `gif`
 
 ##### `options`
 
-Configuration.
+Configuration (optional).
 
 ###### `options.imageExtensions`
 
 List of file extensions recognized as images (`Array.<string>?`, default
-`['svg', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'avif']`).
+[`defaultImageExtensions`](#defaultimageextensions)).
+
+### `defaultImageExtensions`
+
+list of file extensions recognized as an image by default (constant `['svg', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'avif']`).
+Note: extension does not include `.`, only the extension name.
 
 ## Syntax
 

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@
 *   [Install](#install)
 *   [Use](#use)
 *   [API](#api)
-    *   [`unified().use(remarkImages)`](#unifieduseremarkimages)
+    *   [`unified().use(remarkImages[, options])`](#unifieduseremarkimages-options)
 *   [Syntax](#syntax)
 *   [Syntax tree](#syntax-tree)
 *   [Types](#types)
@@ -111,13 +111,22 @@ Below will render an image:
 
 ## API
 
-This package exports no identifiers.
+This package exports `defaultImageExtensions`.
 The default export is `remarkImages`.
 
-### `unified().use(remarkImages)`
+### `unified().use(remarkImages[, options])`
 
 Plugin to add a simpler image syntax.
-There are no options.
+Transform URLs in text that reference images (`png`, `svg`, `jpg`, `jpeg`, `gif`, `webp`, or `avif`) to images.
+
+##### `options`
+
+Configuration.
+
+###### `options.imageExtensions`
+
+List of file extensions recognized as images (`Array.<string>?`, default
+`['svg', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'avif']`).
 
 ## Syntax
 

--- a/test.js
+++ b/test.js
@@ -132,6 +132,15 @@ test('remarkImages', (t) => {
     'should support custom extension as image through options'
   )
 
+  t.equal(
+    remark()
+      .use(remarkImages, {imageExtensions: ['custom']})
+      .processSync('/example.jpg')
+      .toString(),
+    '/example.jpg\n',
+    'should support removing a default extension'
+  )
+
   t.true(
     Array.isArray(defaultImageExtensions) &&
       defaultImageExtensions.every((ext) => typeof ext === 'string'),

--- a/test.js
+++ b/test.js
@@ -87,5 +87,50 @@ test('remarkImages', (t) => {
     'should support image URLs inside other stuff in links'
   )
 
+  t.equal(
+    remark().use(remarkImages).processSync('/example.png').toString(),
+    '[![](/example.png)](/example.png)\n',
+    'should support png extension as image'
+  )
+
+  t.equal(
+    remark().use(remarkImages).processSync('/example.svg').toString(),
+    '[![](/example.svg)](/example.svg)\n',
+    'should support svg extension as image'
+  )
+
+  t.equal(
+    remark().use(remarkImages).processSync('/example.jpeg').toString(),
+    '[![](/example.jpeg)](/example.jpeg)\n',
+    'should support jpeg extension as image'
+  )
+
+  t.equal(
+    remark().use(remarkImages).processSync('/example.gif').toString(),
+    '[![](/example.gif)](/example.gif)\n',
+    'should support gif extension as image'
+  )
+
+  t.equal(
+    remark().use(remarkImages).processSync('/example.webp').toString(),
+    '[![](/example.webp)](/example.webp)\n',
+    'should support webp extension as image'
+  )
+
+  t.equal(
+    remark().use(remarkImages).processSync('/example.avif').toString(),
+    '[![](/example.avif)](/example.avif)\n',
+    'should support avif extension as image'
+  )
+
+  t.equal(
+    remark()
+      .use(remarkImages, {imageExtensions: ['custom']})
+      .processSync('/example.custom')
+      .toString(),
+    '[![](/example.custom)](/example.custom)\n',
+    'should support custom extension as image through options'
+  )
+
   t.end()
 })

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 import test from 'tape'
 import {remark} from 'remark'
-import remarkImages from './index.js'
+import remarkImages, {defaultImageExtensions} from './index.js'
 
 test('remarkImages', (t) => {
   t.equal(
@@ -130,6 +130,12 @@ test('remarkImages', (t) => {
       .toString(),
     '[![](/example.custom)](/example.custom)\n',
     'should support custom extension as image through options'
+  )
+
+  t.true(
+    Array.isArray(defaultImageExtensions) &&
+      defaultImageExtensions.every((ext) => typeof ext === 'string'),
+    'should export default image extensions for reuse'
   )
 
   t.end()


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Makes the extensions supported by `remark-images` configurable through options.
In addition this adds `webp` and `avif` to extensions recognized as images by default.

<!--do not edit: pr-->
